### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/FPSAC/FPSAC2018.cls
+++ b/FPSAC/FPSAC2018.cls
@@ -149,7 +149,7 @@
 %\renewcommand*{\bibfont}{\small}
 %\DeclareFieldFormat[article]{volume}{\mkbibbold{#1}}
 %\DeclareFieldFormat{url}{\textsc{url}: \href{#1}{#1}}
-%\DeclareFieldFormat{doi}{\textsc{doi}: \href{http://dx.doi.org/#1}{#1}}
+%\DeclareFieldFormat{doi}{\textsc{doi}: \href{https://doi.org/#1}{#1}}
 %\DeclareFieldFormat{eprint:arxiv}{arXiv:\href{https://arxiv.org/abs/#1}{#1}}
 
 %%%%%%%%%%%%%%

--- a/FPSAC/aas.tex
+++ b/FPSAC/aas.tex
@@ -13,7 +13,7 @@
 %\usepackage[colorlinks=true, pdfstartview=FitV, linkcolor=blue, citecolor=blue, urlcolor=blue]{hyperref}
 
 % use these commands for typesetting doi and arXiv references in the bibliography
-%\newcommand{\doi}[1]{\href{http://dx.doi.org/#1}{\texttt{doi:#1}}}
+%\newcommand{\doi}[1]{\href{https://doi.org/#1}{\texttt{doi:#1}}}
 \newcommand{\arxiv}[1]{\href{http://arxiv.org/abs/#1}{\texttt{arXiv:#1}}}
 
 % For easier display of e-mail

--- a/mlqs.tex
+++ b/mlqs.tex
@@ -22,7 +22,7 @@
 \usepackage[colorlinks=true, pdfstartview=FitV, linkcolor=blue, citecolor=blue, urlcolor=blue]{hyperref}
 
 % use these commands for typesetting doi and arXiv references in the bibliography
-\newcommand{\doi}[1]{\href{http://dx.doi.org/#1}{\texttt{doi:#1}}}
+\newcommand{\doi}[1]{\href{https://doi.org/#1}{\texttt{doi:#1}}}
 \newcommand{\arxiv}[1]{\href{http://arxiv.org/abs/#1}{\texttt{arXiv:#1}}}
 
 \newcommand{\iso}{\cong}

--- a/queue.bib
+++ b/queue.bib
@@ -518,7 +518,7 @@ MRREVIEWER = {Ellen Saada},
   MRNUMBER = {1904379 (2003f:05124)},
 MRREVIEWER = {Timothy Y. Chow},
        DOI = {10.1007/s00026-001-8008-6},
-       URL = {http://dx.doi.org/10.1007/s00026-001-8008-6},
+       URL = {https://doi.org/10.1007/s00026-001-8008-6},
 }
 
 @article {MGP68,


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!